### PR TITLE
Apply tzinfo before restarting MySQL service

### DIFF
--- a/2-install-guacamole.sh
+++ b/2-install-guacamole.sh
@@ -344,21 +344,6 @@ echo
 # Set MySQL password
 export MYSQL_PWD=${MYSQL_ROOT_PWD}
 
-# Restart MySQL service
-if [ "${INSTALL_MYSQL}" = true ]; then
-    echo -e "${GREY}Restarting MySQL service & enable at boot..."
-    # Set MySQl to start at boot
-    systemctl enable mysql
-    systemctl restart mysql
-    if [ $? -ne 0 ]; then
-        echo -e "${LRED}Failed${GREY}" 1>&2
-        exit 1
-    else
-        echo -e "${LGREEN}OK${GREY}"
-        echo
-    fi
-fi
-
 # Default locations of MySQL config files
 for x in /etc/mysql/mariadb.conf.d/50-server.cnf \
     /etc/mysql/mysql.conf.d/mysqld.cnf \
@@ -399,6 +384,21 @@ if [ $? -ne 0 ]; then
 else
     echo -e "${LGREEN}OK${GREY}"
     echo
+fi
+
+# Restart MySQL service
+if [ "${INSTALL_MYSQL}" = true ]; then
+    echo -e "${GREY}Restarting MySQL service & enable at boot..."
+    # Set MySQl to start at boot
+    systemctl enable mysql
+    systemctl restart mysql
+    if [ $? -ne 0 ]; then
+        echo -e "${LRED}Failed${GREY}" 1>&2
+        exit 1
+    else
+        echo -e "${LGREEN}OK${GREY}"
+        echo
+    fi
 fi
 
 # Create ${GUAC_DB} and grant ${GUAC_USER} permissions to it


### PR DESCRIPTION
By default, if timezone isn't set, MariaDB attempts to parse it from system locale, as can be seen here: https://mariadb.com/kb/en/time-zones/

So the parameter ``default_time_zone`` is set at ``/etc/mysql/mariadb.conf.d/50-server.conf`` on Debian 12 to the system timezone, but the script fails on ``Restarting MySQL service & enable at boot...`` stage because it's timezone info wasn't set on database yet and the MariaDB daemon fails to start.

The following error is thrown on MariaDB logs when attempting to restart MariaDB service without importing the timezone first:

```
unifi@unifi:/etc/mysql/mariadb.conf.d$ sudo journalctl -xeu mariadb.service
ago 09 13:33:16 unifi mariadbd[73176]: 2023-08-09 13:33:16 0 [Note] Server socket created on IP: '127.0.0.1'.
ago 09 13:33:16 unifi mariadbd[73176]: 2023-08-09 13:33:16 0 [ERROR] Fatal error: Illegal or unknown default time zone 'America/Sao_Paulo'
```